### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -25,15 +25,15 @@ read_temperature	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-	tsys01_i2c_address_csb_1 	LITERAL1
-	tsys01_i2c_address_csb_0	LITERAL1
+tsys01_i2c_address_csb_1	LITERAL1
+tsys01_i2c_address_csb_0	LITERAL1
 
-	tsys01_status_ok	LITERAL1,
-	tsys01_status_no_i2c_acknowledge	LITERAL1
-	tsys01_status_i2c_transfer_error	LITERAL1
-	tsys01_status_crc_error		LITERAL1
-	
-	STATUS_OK           	LITERAL1
-   	STATUS_ERR_OVERFLOW	    LITERAL1
-  	STATUS_ERR_TIMEOUT  	LITERAL1
-	
+tsys01_status_ok	LITERAL1,
+tsys01_status_no_i2c_acknowledge	LITERAL1
+tsys01_status_i2c_transfer_error	LITERAL1
+tsys01_status_crc_error	LITERAL1
+
+STATUS_OK	LITERAL1
+STATUS_ERR_OVERFLOW	LITERAL1
+STATUS_ERR_TIMEOUT	LITERAL1
+

--- a/keywords.txt
+++ b/keywords.txt
@@ -29,8 +29,8 @@ read_temperature	KEYWORD2
 	tsys01_i2c_address_csb_0	LITERAL1
 
 	tsys01_status_ok	LITERAL1,
-	tsys01_status_no_i2c_acknowledge	LITERAL1,
-	tsys01_status_i2c_transfer_error	LITERAL1,
+	tsys01_status_no_i2c_acknowledge	LITERAL1
+	tsys01_status_i2c_transfer_error	LITERAL1
 	tsys01_status_crc_error		LITERAL1
 	
 	STATUS_OK           	LITERAL1


### PR DESCRIPTION
- Correct invalid keywords.txt KEYWORD_TOKENTYPEs.
- Use correct field separator.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords