### PR TITLE
Correct invalid keywords.txt KEYWORD_TOKENTYPE

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -28,7 +28,7 @@ read_temperature	KEYWORD2
 tsys01_i2c_address_csb_1	LITERAL1
 tsys01_i2c_address_csb_0	LITERAL1
 
-tsys01_status_ok	LITERAL1,
+tsys01_status_ok	LITERAL1
 tsys01_status_no_i2c_acknowledge	LITERAL1
 tsys01_status_i2c_transfer_error	LITERAL1
 tsys01_status_crc_error	LITERAL1


### PR DESCRIPTION
Use of an invalid KEYWORD_TOKENTYPE value in keywords.txt causes the keyword to be colored by the default editor.function.style (as used by KEYWORD2, KEYWORD3, LITERAL2) in Arduino IDE 1.6.5 and newer. On Arduino IDE 1.6.4 and older this will cause the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype